### PR TITLE
Create `package.json` to prepare for npm release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "thelounge-theme-mircalike",
+  "version": "1.0.0",
+  "description": "A mIRC-looking theme for The Lounge",
+  "main": "package.json",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/gummipunkt/thelounge_theme_mircalike.git"
+  },
+  "keywords": [
+    "thelounge",
+    "thelounge-theme"
+  ],
+  "author": "gummipunkt",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/gummipunkt/thelounge_theme_mircalike/issues"
+  },
+  "homepage": "https://github.com/gummipunkt/thelounge_theme_mircalike#readme",
+  "thelounge": {
+    "css": "mircalike.css",
+    "name": "Mircalike",
+    "type": "theme"
+  }
+}


### PR DESCRIPTION
This file was created by following steps listed at thelounge.github.io/docs/plugins/themes.html.

After publishing it on npm, it will be available with all other themes https://npmjs.com/search?q=keywords%3Athelounge-theme

It can then be installed on The Lounge (as of [v2.5.0](thelounge/lounge@v2.5.0) (release)) using the `lounge install` (prior to v2.7.0) or `thelounge install` (v2.7.0 and up) command.